### PR TITLE
ghc-9.0.2 workaround

### DIFF
--- a/lion-formal/cabal.project
+++ b/lion-formal/cabal.project
@@ -5,3 +5,31 @@ write-ghc-environment-files: always
 
 package clash-prelude
   flags: -large-tuples
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+    subdir: clash-prelude
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+    subdir: clash-ghc
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+    subdir: clash-lib
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/ghc-typelits-extra.git
+    tag: a3ebf6c600dde4d2573096e4ed18012ce732e9c9
+
+source-repository-package
+    type: git
+    location: https://github.com/standardsemiconductor/ice40-prim.git
+    tag: d756d8b52b79caca07c9c03ee42b5a77586c348e

--- a/lion-formal/lion-formal.cabal
+++ b/lion-formal/lion-formal.cabal
@@ -17,7 +17,7 @@ library
   default-language: Haskell2010
   build-depends:
     base          >= 4.13 && < 4.17,
-    clash-prelude >= 1.4  && < 1.5,
+    clash-prelude >= 1.4  && < 1.6,
     lion          >= 0.3  && < 0.4,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,

--- a/lion-metric/cabal.project
+++ b/lion-metric/cabal.project
@@ -5,3 +5,19 @@ write-ghc-environment-files: always
 
 package clash-prelude
   flags: -large-tuples
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/ghc-typelits-extra.git
+    tag: a3ebf6c600dde4d2573096e4ed18012ce732e9c9
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    subdir: clash-prelude clash-ghc clash-lib
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+
+source-repository-package
+    type: git
+    location: https://github.com/standardsemiconductor/ice40-prim.git
+    tag: d756d8b52b79caca07c9c03ee42b5a77586c348e

--- a/lion-metric/lion-metric.cabal
+++ b/lion-metric/lion-metric.cabal
@@ -16,7 +16,7 @@ library
   default-language: Haskell2010
   build-depends:
     base          >= 4.13 && < 4.17,
-    clash-prelude >= 1.4 && < 1.5,
+    clash-prelude >= 1.4 && < 1.6,
     lion          >= 0.3 && < 0.4,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,

--- a/lion-soc/cabal.project
+++ b/lion-soc/cabal.project
@@ -5,3 +5,31 @@ write-ghc-environment-files: always
 
 package clash-prelude
   flags: -large-tuples
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+    subdir: clash-prelude
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+    subdir: clash-ghc
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/clash-compiler.git
+    tag: 3b763b262a5da1460b95b8bfce7c1f31db4b012f
+    subdir: clash-lib
+
+source-repository-package
+    type: git
+    location: https://github.com/clash-lang/ghc-typelits-extra.git
+    tag: a3ebf6c600dde4d2573096e4ed18012ce732e9c9
+
+source-repository-package
+    type: git
+    location: https://github.com/standardsemiconductor/ice40-prim.git
+    tag: d756d8b52b79caca07c9c03ee42b5a77586c348e

--- a/lion-soc/lion-soc.cabal
+++ b/lion-soc/lion-soc.cabal
@@ -21,7 +21,7 @@ library
   default-language: Haskell2010
   build-depends:
     base           >= 4.13 && < 4.17,
-    clash-prelude  >= 1.4 && < 1.5,
+    clash-prelude  >= 1.4 && < 1.6,
     generic-monoid >= 0.1 && < 0.2,
     ice40-prim     >= 0.3 && < 0.4,
     lens,

--- a/lion-soc/src/Soc.hs
+++ b/lion-soc/src/Soc.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Soc
 Description : Lion SoC on the VELDT
-Copyright   : (c) David Cox, 2021
+Copyright   : (c) David Cox, 2021-2022
 License     : BSD-3-Clause
 Maintainer  : standardsemiconductor@gmail.com
 -}
@@ -97,7 +97,7 @@ lion rxIn = FromSoc
 topEntity 
   :: "uart_rx" ::: Signal Lattice12Mhz Bit
   -> FromSoc Lattice12Mhz
-topEntity = withClockResetEnable clk latticeRst enableGen lion
+topEntity = withSpecificClockResetEnable clk latticeRst enableGen lion
   where
     clk = hf12Mhz (pure True :: Signal System Bool)
                   (pure True :: Signal System Bool)


### PR DESCRIPTION
* use source-repos clash-{prelue,ghc,lib} ghc-typelits-extra