### PR TITLE
move startPC configuration back into data-level

### DIFF
--- a/lion-soc/src/Soc.hs
+++ b/lion-soc/src/Soc.hs
@@ -67,6 +67,14 @@ concat4 b3 b2 b1 b0 = b3 ++# b2 ++# b1 ++# b0
 --------------
 -- Lion SoC --
 --------------
+
+-- | Lion core configuration
+lionConfig :: CoreConfig
+lionConfig = CoreConfig
+  { aluConfig  = Hard
+  , pipeConfig = PipeConfig 0x400
+  }
+
 {-# NOINLINE lion #-}
 lion :: HiddenClockResetEnable dom => Signal dom Bit -> FromSoc dom
 lion rxIn = FromSoc
@@ -75,15 +83,13 @@ lion rxIn = FromSoc
   , spiIO  = spiio
   }
   where
-    config :: CoreConfig 'Hard
-    config = CoreConfig $ PipeConfig 0x400
     fromBios         = bios      $ romMap   <$> fromCore
     fromRgb          = rgb       $ ledMap   <$> peripheral <*> fromCore
     (tx, fromUart)   = uart rxIn $ uartMap  <$> peripheral <*> fromCore
     fromSpram        = spram     $ spramMap <$> peripheral <*> fromCore
     (spiio, fromSpi) = S.spi     $ spiMap   <$> peripheral <*> fromCore
     peripheral = selectPeripheral <$> fromCore
-    fromCore = toMem $ core config $ 
+    fromCore = toMem $ core lionConfig $
       busMapOut <$> fromBios 
                 <*> fromUart
                 <*> fromSpram

--- a/lion-soc/src/Soc.hs
+++ b/lion-soc/src/Soc.hs
@@ -75,8 +75,8 @@ lion rxIn = FromSoc
   , spiIO  = spiio
   }
   where
-    config :: CoreConfig 0x400 'Hard
-    config = CoreConfig PipeConfig
+    config :: CoreConfig 'Hard
+    config = CoreConfig $ PipeConfig 0x400
     fromBios         = bios      $ romMap   <$> fromCore
     fromRgb          = rgb       $ ledMap   <$> peripheral <*> fromCore
     (tx, fromUart)   = uart rxIn $ uartMap  <$> peripheral <*> fromCore

--- a/src/Lion/Core.hs
+++ b/src/Lion/Core.hs
@@ -33,8 +33,8 @@ import qualified Lion.Instruction as I (Op(Add))
 -- | Core configuration
 --
 -- ALU configuration default: `Soft`
-newtype CoreConfig (startPC :: Nat) (a :: AluConfig) = CoreConfig
-  { pipeConfig :: P.PipeConfig (startPC :: Nat) -- ^ pipeline configuration
+newtype CoreConfig (a :: AluConfig) = CoreConfig
+  { pipeConfig :: P.PipeConfig -- ^ pipeline configuration
   }
   deriving stock (Generic, Show, Eq)
 
@@ -43,7 +43,7 @@ newtype CoreConfig (startPC :: Nat) (a :: AluConfig) = CoreConfig
 -- ALU configuration = `Soft`
 --
 -- `pipeConfig` = `defaultPipeConfig`
-defaultCoreConfig :: CoreConfig 0 'Soft
+defaultCoreConfig :: CoreConfig 'Soft
 defaultCoreConfig = CoreConfig
   { pipeConfig = P.defaultPipeConfig
   }
@@ -56,11 +56,10 @@ data FromCore dom = FromCore
 
 -- | RISC-V Core: RV32I
 core
-  :: forall a startPC dom
+  :: forall a dom
    . HiddenClockResetEnable dom
   => Alu a
-  => (KnownNat startPC, startPC <= 0xFFFFFFFF)
-  => CoreConfig (startPC :: Nat) (a :: AluConfig) -- ^ core configuration
+  => CoreConfig (a :: AluConfig) -- ^ core configuration
   -> Signal dom (BitVector 32)   -- ^ core input, from memory/peripherals
   -> FromCore dom                -- ^ core output
 core config toCore = FromCore

--- a/src/Lion/Core.hs
+++ b/src/Lion/Core.hs
@@ -38,7 +38,8 @@ data CoreConfig = CoreConfig
 -- | Default core configuration
 --
 -- `aluConfig` = `Soft`
--- `pipeConfig` = `defaultPipeConfig`
+--
+-- `pipeConfig` = `P.defaultPipeConfig`
 defaultCoreConfig :: CoreConfig
 defaultCoreConfig = CoreConfig
   { aluConfig  = Soft

--- a/src/Lion/Core.hs
+++ b/src/Lion/Core.hs
@@ -18,11 +18,9 @@ module Lion.Core
   , FromCore(..)
   , P.ToMem(..)
   , P.MemoryAccess(..)
-  , Alu
   ) where
 
 import Clash.Prelude
-import Data.Proxy
 import Data.Maybe
 import Data.Monoid
 import Lion.Alu
@@ -31,21 +29,20 @@ import qualified Lion.Pipe as P
 import qualified Lion.Instruction as I (Op(Add))
 
 -- | Core configuration
---
--- ALU configuration default: `Soft`
-newtype CoreConfig (a :: AluConfig) = CoreConfig
-  { pipeConfig :: P.PipeConfig -- ^ pipeline configuration
+data CoreConfig = CoreConfig
+  { aluConfig  :: AluConfig    -- ^ ALU configuration, default: `Soft`
+  , pipeConfig :: P.PipeConfig -- ^ pipeline configuration
   }
   deriving stock (Generic, Show, Eq)
 
 -- | Default core configuration
 --
--- ALU configuration = `Soft`
---
+-- `aluConfig` = `Soft`
 -- `pipeConfig` = `defaultPipeConfig`
-defaultCoreConfig :: CoreConfig 'Soft
+defaultCoreConfig :: CoreConfig
 defaultCoreConfig = CoreConfig
-  { pipeConfig = P.defaultPipeConfig
+  { aluConfig  = Soft
+  , pipeConfig = P.defaultPipeConfig
   }
 
 -- | Core outputs
@@ -56,12 +53,10 @@ data FromCore dom = FromCore
 
 -- | RISC-V Core: RV32I
 core
-  :: forall a dom
-   . HiddenClockResetEnable dom
-  => Alu a
-  => CoreConfig (a :: AluConfig) -- ^ core configuration
-  -> Signal dom (BitVector 32)   -- ^ core input, from memory/peripherals
-  -> FromCore dom                -- ^ core output
+  :: HiddenClockResetEnable dom
+  => CoreConfig                 -- ^ core configuration
+  -> Signal dom (BitVector 32)  -- ^ core input, from memory/peripherals
+  -> FromCore dom               -- ^ core output
 core config toCore = FromCore
   { toMem  = getFirst . P._toMem <$> fromPipe
   , toRvfi = fromMaybe mkRvfi . getFirst . P._toRvfi <$> fromPipe
@@ -71,7 +66,8 @@ core config toCore = FromCore
     aluOp = fromMaybe I.Add . getFirst . P._toAluOp     <$> fromPipe
     aluInput1 = fromMaybe 0 . getFirst . P._toAluInput1 <$> fromPipe
     aluInput2 = fromMaybe 0 . getFirst . P._toAluInput2 <$> fromPipe
-    aluOutput = alu (Proxy :: Proxy a) aluOp aluInput1 aluInput2
+    aluOutput = alu (aluConfig config) aluOp aluInput1 aluInput2
+
     -- reg bank connection
     rs1Addr = fromMaybe 0 . getFirst . P._toRs1Addr <$> fromPipe
     rs2Addr = fromMaybe 0 . getFirst . P._toRs2Addr <$> fromPipe


### PR DESCRIPTION
* Move configuration variables (ALU config, startPC config) back into data-level
* Simplify interface
* Increase composability