### PR TITLE
Update ice40-prim dependency bounds

### DIFF
--- a/lion.cabal
+++ b/lion.cabal
@@ -31,7 +31,7 @@ library
     generic-monoid >= 0.1   && < 0.2,
     mtl            >= 2.2   && < 2.3,
     lens           >= 4.19  && < 5.2,
-    ice40-prim     >= 0.3   && < 0.4,
+    ice40-prim     >= 0.3   && < 0.3.1.4,
     clash-prelude  >= 1.2.5 && < 1.7,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,


### PR DESCRIPTION
Exclude ice40-prim-0.3.1.4