### PR TITLE
Ghc and library updates

### DIFF
--- a/lion-formal/lion-formal.cabal
+++ b/lion-formal/lion-formal.cabal
@@ -16,8 +16,8 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   build-depends:
-    base          >= 4.13 && < 4.17,
-    clash-prelude >= 1.4  && < 1.7,
+    base          >= 4.13 && < 4.21,
+    clash-prelude >= 1.4  && < 1.9,
     lion          >= 0.4  && < 0.5,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,

--- a/lion-metric/lion-metric.cabal
+++ b/lion-metric/lion-metric.cabal
@@ -15,8 +15,8 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   build-depends:
-    base          >= 4.13 && < 4.17,
-    clash-prelude >= 1.4  && < 1.7,
+    base          >= 4.13 && < 4.21,
+    clash-prelude >= 1.4  && < 1.9,
     lion          >= 0.4  && < 0.5,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
@@ -40,7 +40,7 @@ library
 
 executable metric
   main-is: Main.hs
-  build-depends: base >= 4.13 && < 4.16
+  build-depends: base >= 4.13 && < 4.21
                , clash-ghc
                , shake
   hs-source-dirs: app

--- a/lion-soc/lion-soc.cabal
+++ b/lion-soc/lion-soc.cabal
@@ -20,13 +20,13 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   build-depends:
-    base           >= 4.13 && < 4.17,
-    clash-prelude  >= 1.4 && < 1.7,
+    base           >= 4.13 && < 4.21,
+    clash-prelude  >= 1.4 && < 1.9,
     generic-monoid >= 0.1 && < 0.2,
     ice40-prim     >= 0.3 && < 0.4,
     lens,
     lion           >= 0.4 && < 0.5,
-    mtl            >= 2.2 && < 2.3,
+    mtl            >= 2.2 && < 2.4,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat

--- a/lion-soc/src/Spi.hs
+++ b/lion-soc/src/Spi.hs
@@ -20,10 +20,12 @@ import Clash.Prelude
 import Control.Monad.RWS
 import Control.Lens hiding (Index)
 import Data.Maybe ( fromMaybe, isJust )
+import Data.Monoid (First(..))
 import Data.Monoid.Generic
 import qualified Ice40.Spi as S
 import Ice40.IO
 import Bus
+import Control.Monad (when)
 
 data SpiIO = SpiIO ("biwo" ::: Bit)
                    ("bowi" ::: Bit)
@@ -52,8 +54,8 @@ data FromSysBus = FromSysBus
   deriving Monoid via GenericMonoid FromSysBus
 makeLenses ''FromSysBus
 
-data SysBus = SysBus 
-  { _sbInstr :: Maybe (BitVector 8, Maybe (BitVector 8)) 
+data SysBus = SysBus
+  { _sbInstr :: Maybe (BitVector 8, Maybe (BitVector 8))
   , _sbRecv  :: BitVector 8
   }
   deriving stock (Generic, Show, Eq)
@@ -88,7 +90,7 @@ sysBusM = do
         Nothing ->           -- idle, execute command
           let isWrite = bitToBool $ wr!(16 :: Index 32)
               adri = slice d15 d8 wr
-              dati = slice d7  d0 wr 
+              dati = slice d7  d0 wr
           in sbInstr ?= if isWrite
                then (adri, Just dati)
                else (adri, Nothing)
@@ -99,7 +101,7 @@ sysBusM = do
         then 0x01000000
         else 0x00000000
 
-sysBus 
+sysBus
   :: HiddenClockResetEnable dom
   => Signal dom ToSysBus
   -> Signal dom FromSysBus
@@ -120,7 +122,7 @@ spi toSpi = (spiIO, fromSpi)
     fromSysBus = sysBus $ ToSysBus <$> sbacko
                                    <*> sbdato
                                    <*> toSpi
-   
+
     spiIO = SpiIO <$> biwo <*> bowi <*> wck <*> cs
     (biwo, bi)   = biwoIO woe    wo
     (bowi, wi)   = bowiIO boe    bo
@@ -132,7 +134,7 @@ spi toSpi = (spiIO, fromSpi)
     adri = fromMaybe 0 . getFirst . _sbAdrI <$> fromSysBus
     dati = fromMaybe 0 . getFirst . _sbDatI <$> fromSysBus
 
-    (sbdato, sbacko, _, _, wo, woe, bo, boe, wcko, wckoe, bcsno, bcsnoe) 
+    (sbdato, sbacko, _, _, wo, woe, bo, boe, wcko, wckoe, bcsno, bcsnoe)
       = S.spi "0b0000"
               rwi
               stbi
@@ -144,8 +146,8 @@ spi toSpi = (spiIO, fromSpi)
               wcsni
 
 {-# NOINLINE biwoIO #-}
-biwoIO 
-  :: HiddenClock dom 
+biwoIO
+  :: HiddenClock dom
   => Signal dom Bit
   -> Signal dom Bit
   -> Unbundled dom (Bit, Bit)
@@ -165,10 +167,10 @@ biwoIO woe wo = (biwo, bi)
                        0
 
 {-# NOINLINE bowiIO #-}
-bowiIO 
-  :: HiddenClock dom 
-  => Signal dom Bit 
-  -> Signal dom Bit 
+bowiIO
+  :: HiddenClock dom
+  => Signal dom Bit
+  -> Signal dom Bit
   -> Unbundled dom (Bit, Bit)
 bowiIO boe bo = (bowi, wi)
   where
@@ -186,10 +188,10 @@ bowiIO boe bo = (bowi, wi)
                        0
 
 {-# NOINLINE wckIO #-}
-wckIO 
-  :: HiddenClock dom 
-  => Signal dom Bit 
-  -> Signal dom Bit 
+wckIO
+  :: HiddenClock dom
+  => Signal dom Bit
+  -> Signal dom Bit
   -> Unbundled dom (Bit, Bit)
 wckIO wckoe wcko = (wck, wcki)
   where
@@ -207,10 +209,10 @@ wckIO wckoe wcko = (wck, wcki)
                         0
 
 {-# NOINLINE csIO #-}
-csIO 
-  :: HiddenClock dom 
-  => Signal dom (BitVector 4) 
-  -> Signal dom (BitVector 4) 
+csIO
+  :: HiddenClock dom
+  => Signal dom (BitVector 4)
+  -> Signal dom (BitVector 4)
   -> Unbundled dom (Bit, Bit)
 csIO bcsnoe bcsno = (cs, wcsni)
   where
@@ -226,5 +228,5 @@ csIO bcsnoe bcsno = (cs, wcsni)
                         ((! (3 :: Index 4)) <$> bcsnoe) -- output enable
                         ((! (3 :: Index 4)) <$> bcsno)  -- dOut0
                         0 -- dOut1
-                
-                     
+
+

--- a/lion.cabal
+++ b/lion.cabal
@@ -26,13 +26,13 @@ library
                  , Lion.Pipe
   hs-source-dirs: src
   default-language: Haskell2010
-  build-depends: 
-    base           >= 4.13  && < 4.17,
+  build-depends:
+    base           >= 4.13  && < 4.21,
     generic-monoid >= 0.1   && < 0.2,
-    mtl            >= 2.2   && < 2.3,
-    lens           >= 4.19  && < 5.2,
-    ice40-prim     >= 0.3   && < 0.3.1.4,
-    clash-prelude  >= 1.2.5 && < 1.7,
+    mtl            >= 2.2   && < 2.4,
+    lens           >= 4.19  && < 5.4,
+    ice40-prim     >= 0.3   && < 0.3.1.5,
+    clash-prelude  >= 1.2.5 && < 1.9,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat

--- a/src/Lion/Alu.hs
+++ b/src/Lion/Alu.hs
@@ -1,4 +1,4 @@
-{-| 
+{-|
 Module      : Lion.Alu
 Description : Lion arithmetic logic unit
 Copyright   : (c) David Cox, 2021-2024
@@ -10,7 +10,7 @@ Configurable alu, choose between soft and hard adders/subtractors
 
 module Lion.Alu where
 
-import Clash.Prelude
+import Clash.Prelude hiding (And(..), Xor(..))
 import Data.Function ( on )
 import Ice40.Mac (
   Input(..),
@@ -45,7 +45,7 @@ softAlu
  -> Signal dom (BitVector 32)
 softAlu op in1 = register 0 . liftA3 aluFunc op in1
     where
-      aluFunc = \case 
+      aluFunc = \case
         Add  -> (+)
         Sub  -> (-)
         Sll  -> \x y -> x `shiftL` shamt y
@@ -73,13 +73,13 @@ hardAlu op in1 in2 = mux isAddSub adderSubtractor $ register 0 $ baseAlu op in1 
       isSub = (Sub == ) <$> op
       isAddSub = delay False $ isAdd .||. isSub
       adderSubtractor = hardAddSub (boolToBit <$> isSub) in1 in2
-  
+
 baseAlu
   :: Signal dom Op
   -> Signal dom (BitVector 32)
   -> Signal dom (BitVector 32)
   -> Signal dom (BitVector 32)
-baseAlu = liftA3 $ \case 
+baseAlu = liftA3 $ \case
   Add  -> \_ _ -> 0
   Sub  -> \_ _ -> 0
   Sll  -> \x y -> x `shiftL` shamt y

--- a/src/Lion/Instruction.hs
+++ b/src/Lion/Instruction.hs
@@ -8,7 +8,7 @@ Maintainer  : standardsemiconductor@gmail.com
 
 module Lion.Instruction where
 
-import Clash.Prelude
+import Clash.Prelude hiding (Xor(Xor), And(And))
 import Data.Function ( on )
 
 data Exception = IllegalInstruction
@@ -26,7 +26,7 @@ data WbInstr = WbRegWr (Unsigned 5) (BitVector 32)
 -- | Memory pipeline instruction
 data MeInstr = MeRegWr      (Unsigned 5)
              | MeJump       (Unsigned 5) (BitVector 32)
-             | MeBranch 
+             | MeBranch
              | MeStore                   (BitVector 32) (BitVector 4) (BitVector 32)
              | MeLoad  Load (Unsigned 5) (BitVector 32) (BitVector 4)
              | MeNop
@@ -155,7 +155,7 @@ parseInstr i = case i of
 
     immI :: BitVector 32
     immI = signExtend $ slice d31 d20 i
-    
+
     immS :: BitVector 32
     immS = signExtend $ slice d31 d25 i ++# slice d11 d7 i
 
@@ -164,7 +164,7 @@ parseInstr i = case i of
 
     immU :: BitVector 32
     immU = slice d31 d12 i ++# 0
-    
+
     immJ :: BitVector 32
     immJ = signExtend (slice d31 d31 i ++# slice d19 d12 i ++# slice d20 d20 i ++# slice d30 d25 i ++# slice d24 d21 i) `shiftL` 1
 

--- a/src/Lion/Pipe.hs
+++ b/src/Lion/Pipe.hs
@@ -15,6 +15,8 @@ import Data.Maybe ( isJust )
 import Data.Monoid.Generic
 import Lion.Instruction
 import Lion.Rvfi
+import Data.Monoid (First(..))
+import Control.Monad (unless)
 
 -- | Pipeline configuration
 newtype PipeConfig = PipeConfig
@@ -22,7 +24,7 @@ newtype PipeConfig = PipeConfig
   } deriving stock (Generic, Show, Eq)
 
 -- | Default pipeline configuration
--- 
+--
 -- `startPC` = 0
 defaultPipeConfig :: PipeConfig
 defaultPipeConfig = PipeConfig 0
@@ -55,7 +57,7 @@ data ToMem = ToMem
   deriving anyclass NFDataX
 
 -- | Construct instruction memory access
-instrMem 
+instrMem
   :: BitVector 32 -- ^ instruction address
   -> ToMem
 instrMem addr = ToMem
@@ -66,7 +68,7 @@ instrMem addr = ToMem
   }
 
 -- | Construct data memory access
-dataMem 
+dataMem
   :: BitVector 32         -- ^ memory address
   -> BitVector 4          -- ^ byte mask
   -> Maybe (BitVector 32) -- ^ write
@@ -111,8 +113,8 @@ data Control = Control
 makeLenses ''Control
 
 mkControl :: Control
-mkControl = Control 
-  { _firstCycle  = True   
+mkControl = Control
+  { _firstCycle  = True
   , _exBranching = Nothing
   , _meBranching = False
   , _deLoad      = False
@@ -156,9 +158,9 @@ mkPipe :: PipeConfig -> Pipe
 mkPipe pipeConfig = Pipe
   { _fetchPC = startPC pipeConfig
 
-  -- decode stage 
+  -- decode stage
   , _dePC    = 0
-  
+
   -- execute stage
   , _exIR    = Nothing
   , _exPC    = 0
@@ -169,18 +171,18 @@ mkPipe pipeConfig = Pipe
   -- memory stage
   , _meIR    = Nothing
   , _meRvfi  = mkRvfi
- 
+
   -- writeback stage
   , _wbIR    = Nothing
   , _wbNRet  = 0
   , _wbRvfi  = mkRvfi
-  
+
   -- pipeline control
   , _control = mkControl
   }
 
 -- | 5-Stage RISC-V pipeline
-pipe 
+pipe
   :: HiddenClockResetEnable dom
   => PipeConfig
   -> Signal dom ToPipe
@@ -188,7 +190,7 @@ pipe
 pipe config = mealy pipeMealy (mkPipe config)
   where
     pipeMealy s i = let ((), s', o) = runRWS pipeM i s
-                    in (s', o) 
+                    in (s', o)
 
 -- | Monadic pipeline
 pipeM :: RWS ToPipe FromPipe Pipe ()
@@ -329,21 +331,21 @@ execute = do
       scribe toAluInput1 $ First $ Just in1
       scribe toAluInput2 $ First $ Just in2
 
-    regFwd 
-      :: MonadState s m 
+    regFwd
+      :: MonadState s m
       => MonadReader r m
-      => Lens' s (Unsigned 5) 
+      => Lens' s (Unsigned 5)
       -> Lens' r (BitVector 32)
       -> Lens' s (Maybe (Unsigned 5, BitVector 32))
       -> Lens' s (Maybe (Unsigned 5, BitVector 32))
       -> m (BitVector 32)
-    regFwd rsAddr rsData meFwd wbFwd = 
+    regFwd rsAddr rsData meFwd wbFwd =
       guardZero rsAddr =<< fwd <$> use rsAddr <*> view rsData <*> use meFwd <*> use wbFwd
       where
         guardZero  -- register x0 always has value 0.
-          :: MonadState s m 
-          => Lens' s (Unsigned 5) 
-          -> BitVector 32 
+          :: MonadState s m
+          => Lens' s (Unsigned 5)
+          -> BitVector 32
           -> m (BitVector 32)
         guardZero addr value = do
           isZero <- uses addr (== 0)
@@ -375,7 +377,7 @@ decode = do
     Left IllegalInstruction -> do -- trap and instr=Nop (addi x0 x0 0)
       unless bubble $ exIR ?= ExAlu Add 0
       exRvfi.rvfiTrap .= True
-        
+
 -- | fetch instruction
 fetch :: RWS ToPipe FromPipe Pipe ()
 fetch = do
@@ -391,9 +393,9 @@ fetch = do
 -------------
 
 -- | forward register writes
-fwd 
-  :: Unsigned 5 
-  -> BitVector 32 
+fwd
+  :: Unsigned 5
+  -> BitVector 32
   -> Maybe (Unsigned 5, BitVector 32) -- ^ meRegFwd
   -> Maybe (Unsigned 5, BitVector 32) -- ^ wbRegFwd
   -> BitVector 32


### PR DESCRIPTION
Some updates to get lion building with newer GHC and Clash versions. This was the bare minimum I needed to get a working build, so happy to make changes. As far as I can tell, all projects build and run now with GHC 9.8 and Clash 1.8.1.